### PR TITLE
Change logo click redirection to '/PicConvert/'

### DIFF
--- a/Website/app.js
+++ b/Website/app.js
@@ -15,7 +15,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // Handle logo click - Redirect to home
-    logo.addEventListener('click', () => window.location.href = '/');
+    logo.addEventListener('click', () => window.location.href = '/PicConvert/');
 
     // Handle menu icon click - Toggle navigation menu
     menuIcon.addEventListener('click', () => {


### PR DESCRIPTION
Updated the event listener for the logo click to redirect users to the '/PicConvert/' URL instead of the root URL ('/').